### PR TITLE
Added environment support for configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ return msg;
 > Always use the `payload` variable to pass your arguments.
 
 
+## Configurations
+
+You can put `${ENV_VAR}` into the input fields of your configuration node to use your environment variables.
+
+
 ## Troubleshooting
 
 

--- a/src/main.html
+++ b/src/main.html
@@ -75,6 +75,10 @@
     Add the credentials for accessing your database here.<br />
     You can find your credentials on Stackhero by choosing your MySQL service and then clicking on the "Configure" button.
   </p>
+  <h3>Use Environment</h3>
+  <p>
+    Write "${ENV_VARNAME}" into the configuration fields to use configurations from your environment variables.
+  </p>
 </script>
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ module.exports = (RED) => {
         return;
       }
 
-      if (msg.payload !== undefined && !(msg.payload instanceof Object)) {
+      if (msg.payload !== undefined && !(typeof msg.payload === 'object')) {
         this.error('msg.payload should be an object containing the query arguments.');
         return;
       }

--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ module.exports = (RED) => {
         return;
       }
 
-      if (msg.payload !== undefined && !(typeof msg.payload === 'object')) {
+      if (msg.payload !== undefined && !(msg.payload === Object(msg.payload) && !Array.isArray(msg.payload))) {
         this.error('msg.payload should be an object containing the query arguments.');
         return;
       }


### PR DESCRIPTION
## Description
You can put `${ENV_VAR}` into the input fields of your configuration node to use your environment variables.

It is inspired by [node-red-contrib-telegrambot](https://github.com/windkh/node-red-contrib-telegrambot)

## Changes:
* added simplified sandbox object to load environment, context, flow or global varables
* added a function `getConfig()` to check if it is an environment/context variable or not.
* updated readme

### others:
* enhanced input filter for payload