### PR TITLE
Fix object validation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ module.exports = (RED) => {
         return;
       }
 
-      if (msg.payload !== undefined && !(msg.payload instanceof Object)) {
+      if (msg.payload !== undefined && !(typeof msg.payload === 'object')) {
         this.error('msg.payload should be an object containing the query arguments.');
         return;
       }

--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ module.exports = (RED) => {
         return;
       }
 
-      if (msg.payload !== undefined && !(typeof msg.payload === 'object')) {
+      if (msg.payload !== undefined && !(msg.payload === Object(msg.payload) && !Array.isArray(msg.payload))) {
         this.error('msg.payload should be an object containing the query arguments.');
         return;
       }


### PR DESCRIPTION
### Description / reason:
The current check if the payload is an object leads to errors despite correct payload.

### Improvement:
Way of checking if the payload is an object.