### PR TITLE
Add SSL support for database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- 🔐 Add new ssl options for securing connections with certificates
+
+
 ## 1.0.5 (2021-01-25)
 
 - 🐞 Fix an issue where msg.payload wasn't checked well (see #3)

--- a/src/main.html
+++ b/src/main.html
@@ -13,6 +13,25 @@
     <label for="node-config-input-tls" style="width:auto !important;"> Encrypt connection to database</label>
   </div>
   <div class="form-row">
+    <label for="node-config-input-rejectUnauthorized"></label>
+    <input type="checkbox" id="node-config-input-rejectUnauthorized"
+           style="display:inline-block; width:auto; vertical-align:top;">
+    <label for="node-config-input-rejectUnauthorized" style="width:auto !important;"> Verify certificate
+      (recommended)</label>
+  </div>
+  <div class="form-row">
+    <label for="node-config-input-caCertificate"><i class="fa fa-certificate"></i> CA-Cert.</label>
+    <input type="text" id="node-config-input-caCertificate">
+  </div>
+  <div class="form-row">
+    <label for="node-config-input-cert"><i class="fa fa-certificate"></i> Cert</label>
+    <input type="text" id="node-config-input-cert">
+  </div>
+  <div class="form-row">
+    <label for="node-config-input-key"><i class="fa fa-key"></i> Key</label>
+    <input type="text" id="node-config-input-key">
+  </div>
+  <div class="form-row">
     <label for="node-config-input-user"><i class="fa fa-user"></i> User</label>
     <input type="text" id="node-config-input-user">
   </div>
@@ -49,6 +68,22 @@
         value: true,
         required: true
       },
+      rejectUnauthorized: {
+        value: true,
+        required: true
+      },
+      caCertificate: {
+        value: "",
+        required: false
+      },
+      cert: {
+        value: "",
+        required: false
+      },
+      key: {
+        value: "",
+        required: false
+      },
       database: {
         value: "",
         required: true
@@ -65,6 +100,21 @@
     // Note: label (and probably labelStyle) have to be a classical function (not an arrow function)
     label: function () {
       return this.name || this.database
+    },
+    oneditprepare: function () {
+      function toggleTlsFields(show) {
+        $("#node-config-input-caCertificate").closest('div').toggle(show);
+        $("#node-config-input-cert").closest('div').toggle(show);
+        $("#node-config-input-key").closest('div').toggle(show);
+        $("#node-config-input-rejectUnauthorized").closest('div').toggle(show);
+      }
+
+      const tlsCheckbox = $("#node-config-input-tls");
+      tlsCheckbox.on('change', function () {
+        toggleTlsFields(this.checked);
+      });
+
+      toggleTlsFields(tlsCheckbox.prop('checked'));
     }
   });
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 module.exports = (RED) => {
   'use strict';
 
@@ -39,6 +41,38 @@ module.exports = (RED) => {
         return;
       }
 
+      let sslOptions;
+      if (config.tls) {
+        sslOptions = {};
+        if (config.caCertificate) {
+          try {
+            sslOptions.ca = fs.readFileSync(config.caCertificate);
+          } catch (err) {
+            this.error(`Unable to read CA-Certificate: ${err}`);
+            return;
+          }
+        }
+        if (config.cert) {
+          try {
+            sslOptions.ca = fs.readFileSync(config.cert)
+          } catch (err) {
+            this.error(`Unable to read cert: ${err}`);
+            return;
+          }
+        }
+        if (config.key) {
+          try {
+            sslOptions.ca = fs.readFileSync(config.key)
+          } catch (err) {
+            this.error(`Unable to read key: ${err}`);
+            return;
+          }
+        }
+        sslOptions.rejectUnauthorized = config.rejectUnauthorized;
+      } else {
+        sslOptions = false;
+      }
+
       // Note: the connection is not done here
       this.pool = mysql.createPool({
         host: config.host,
@@ -50,7 +84,7 @@ module.exports = (RED) => {
         connectionLimit: 5,
         queueLimit: 0,
         connectTimeout: 1000,
-        ssl: config.tls ? {} : false,
+        ssl: sslOptions,
 
         // See https://www.npmjs.com/package/mysql#custom-format
         queryFormat: (query, values) => {


### PR DESCRIPTION
This update adds SSL support for the database connection in main.js and introduces new form fields in main.html to handle SSL-related configurations like CA-Certificate, Cert, and Key. It also includes error handling for failed certificate reads. It enhances security by enabling encrypted connections to databases using certificates.

This PR addresses the issue #10