### PR TITLE
Support Array of values for bulk inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ msg.topic = 'SELECT * FROM `users` WHERE `name` = :name AND `age` > :age;';
 msg.payload = { name: 'Adrien', age: 30 };
 return msg;
 ```
+If you have multiple arguments, put them in an array of objects in the `payload` variable.
+You will get the result in the `payload` output variable.
 
+Example:
+
+```javascript
+msg.topic = 'INSERT INTO `users` (`name`,  `age`) VALUES( :name, :age) ;';
+msg.payload = [
+  { name: 'Adrien', age: 30 },
+  { name: 'Maria', age: 62 }
+]
+return msg;
+```
 > Avoid SQL injections!!
 >
 > Do not NEVER EVER put variables content in `topic` directly!

--- a/src/main.js
+++ b/src/main.js
@@ -147,7 +147,6 @@ module.exports = (RED) => {
               connection.release();
             });
           }
-          let result = [];
           let promisses = [];
           msg.payload = values.forEach((value) => {
             promisses.push(

--- a/src/main.js
+++ b/src/main.js
@@ -177,6 +177,7 @@ module.exports = (RED) => {
                       thisNode.setState("error", error.toString());
                     });
                   } else {
+                    connection.commit();
                     connection.release();
                     msg.payload = results;
                     thisNode.setState("queryDone");
@@ -185,6 +186,9 @@ module.exports = (RED) => {
                 })
               
             }).catch((error) => {
+              connection.rollback(function () {
+                connection.release();
+              });
               thisNode.error(error);
               thisNode.setState("error", error.toString());
             });;
@@ -193,6 +197,8 @@ module.exports = (RED) => {
     });
 
     this.on('close', async () => {
+
+  
       this.serverConfig.removeAllListeners();
       this.setState();
     });


### PR DESCRIPTION
This fix avoids locked objects when inserting multiple rows to the same table by firing multiple query requests.
The queries can run at the same time and generate locking errors.

Example: msg.payload contains array of objects to insert.
A split node  generates an single payload for each of them and passes them to the mysql node.
You might get lock errors, because all values will be executed  in paralell

It's better to execute all inserts in one statements  and in one transaction.

If the payload, contains an array, all objects in that array will be processed in one transaction.
No split node is required.
if the payload contains an object, it's treated as an array with one entry.

Example topic and payload
```
msg.topic = "insert into test (date_hour, price) " +
    "select :hour, :price  from dual where not exists( select hour from test where " +
    "hour =:hour);\n"

msg.payload  = [{ date_hour: 1234, price:0.234},{ date_hour: 12345, price:0.235}]
return msg;

```